### PR TITLE
Keep Linker name in pt-br translation

### DIFF
--- a/docs/ios/deploy-test/linker.md
+++ b/docs/ios/deploy-test/linker.md
@@ -1,6 +1,6 @@
 ---
-title: Vinculando aplicativos Xamarin.iOS
-description: Este documento descreve o vinculador do Xamarin.iOS, que é usado para eliminar código não utilizado de um aplicativo Xamarin.iOS a fim de reduzir seu tamanho.
+title: Usando Linker em aplicativos Xamarin.iOS
+description: Este documento descreve o Linker do Xamarin.iOS, que é usado para eliminar código não utilizado de um aplicativo Xamarin.iOS a fim de reduzir seu tamanho.
 ms.prod: xamarin
 ms.assetid: 3A4B2178-F264-0E93-16D1-8C63C940B2F9
 ms.technology: xamarin-ios
@@ -14,27 +14,27 @@ ms.contentlocale: pt-BR
 ms.lasthandoff: 06/22/2018
 ms.locfileid: "36321451"
 ---
-# <a name="linking-xamarinios-apps"></a>Vinculando aplicativos Xamarin.iOS
+# <a name="linking-xamarinios-apps"></a>Usando Linker em aplicativos Xamarin.iOS
 
-Ao compilar seu aplicativo, o Visual Studio para Mac ou o Visual Studio chama uma ferramenta chamada **mtouch**, que inclui um vinculador para código gerenciado. Ele é usado para remover os recursos que o aplicativo não está usando das bibliotecas de classe. A meta é reduzir o tamanho do aplicativo, que será fornecido com apenas os bits necessários.
+Ao compilar seu aplicativo, o Visual Studio for Mac ou o Visual Studio chama uma ferramenta chamada **mtouch**, que inclui um linker para código gerenciado. Ele é usado para remover os recursos que o aplicativo não está usando das class libraries. A meta é reduzir o tamanho do aplicativo, que será fornecido com apenas as partes necessárias.
 
-O vinculador usa análise estática para determinar os diferentes caminhos de código que seu aplicativo é suscetível a seguir. Ela é um pouco pesada, já que precisa passar por todos os detalhes de cada assembly, para verificar se nada detectável foi removido. Ele não é habilitado por padrão em builds do simulador para acelerar o tempo de compilação durante a depuração. No entanto, já que ele produz aplicativos menores e que pode acelerar a compilação AOT e o upload para o dispositivo, todos os *builds de dispositivos (versão)* estão usando o vinculador por padrão.
+O linker usa análise estática para determinar os diferentes caminhos de código que seu aplicativo é suscetível a seguir. Ela é um pouco pesada, já que precisa passar por todos os detalhes de cada assembly, para verificar se nada detectável foi removido. Ele não é habilitado por padrão em builds do simulador para acelerar o tempo de compilação durante a depuração. No entanto, já que ele produz aplicativos menores e que pode acelerar a compilação AOT e o upload para o dispositivo, todos os *builds de dispositivos (Release)* estão usando o linker por padrão.
 
-Já que o vinculador é uma ferramenta estática, ele não pode marcar para tipos de inclusão e métodos que são chamados por meio de reflexão, ou instanciados dinamicamente. Há várias opções de soluções alternativas para essa limitação.
+Já que o linker é uma ferramenta estática, ele não pode marcar para inclusão tipos e métodos que são chamados por meio de reflection, ou instanciados dinamicamente. Há várias opções de soluções alternativas para essa limitação.
 
 <a name="Linker_Behavior" />
 
-## <a name="linker-behavior"></a>Comportamento do vinculador
+## <a name="linker-behavior"></a>Comportamento do Linker
 
-# <a name="visual-studio-for-mactabvsmac"></a>[Visual Studio para Mac](#tab/vsmac)
+# <a name="visual-studio-for-mactabvsmac"></a>[Visual Studio for Mac](#tab/vsmac)
 
-O processo de vinculação pode ser personalizado por meio do menu suspenso de comportamento do vinculador em **Opções do Projeto**. Para acessá-lo, clique duas vezes no projeto iOS e navegue até **Build do iOS > Opções do Vinculador**, conforme ilustrado abaixo:
+O processo de _linking_ pode ser personalizado por meio do menu suspenso de comportamento do linker em **Opções do Projeto**. Para acessá-lo, clique duas vezes no projeto iOS e navegue até **Build do iOS > Opções do Linker**, conforme ilustrado abaixo:
 
 [![](linker-images/image1.png "Opções do Vinculador")](linker-images/image1.png#lightbox)
 
 # <a name="visual-studiotabvswin"></a>[Visual Studio](#tab/vswin)
 
-O processo de vinculação pode ser personalizado por meio do menu suspenso de comportamento do vinculador nas **Propriedades do Projeto** no Visual Studio.
+O processo de _linking_ pode ser personalizado por meio do menu suspenso de comportamento do linker nas **Propriedades do Projeto** no Visual Studio.
 
 Faça o seguinte:
 
@@ -44,16 +44,15 @@ Faça o seguinte:
 2. Nas **Propriedades do Projeto**, selecione **Build do iOS**:
 
     ![](linker-images/linking02w.png "Selecionar Build do iOS")
-3. Siga as instruções abaixo para alterar as opções de vinculação.
+3. Siga as instruções abaixo para alterar as opções do linker.
 
 -----
 
 As três principais opções oferecidas são descritas a seguir:
 
-
 ### <a name="dont-link"></a>Não Vincular
 
-Desabilitar a vinculação assegura que nenhum assembly seja modificado. Por motivos de desempenho, essa é a configuração padrão quando o seu IDE se destina ao simulador de iOS. Para builds de dispositivos, isso só deve ser usado como uma solução alternativa sempre que o vinculador contém um bug que impede que o aplicativo seja executado. Se o aplicativo funciona apenas com *-nolink*, envie um [relatório de bug](http://bugzilla.xamarin.com).
+Desabilitar o _linker_ assegura que nenhum assembly seja modificado. Por motivos de desempenho, essa é a configuração padrão quando o seu IDE se destina ao simulador de iOS. Para builds de dispositivos, isso só deve ser usado como uma solução alternativa sempre que o vinculador contém um bug que impede que o aplicativo seja executado. Se o aplicativo funciona apenas com *-nolink*, envie um [relatório de bug](http://bugzilla.xamarin.com).
 
 Isso corresponde à opção *-nolink* ao usar a ferramenta de linha de comando mtouch.
 
@@ -61,9 +60,9 @@ Isso corresponde à opção *-nolink* ao usar a ferramenta de linha de comando m
 
 ### <a name="link-sdk-assemblies-only"></a>Vincular somente os assemblies do SDK
 
-Nesse modo, o vinculador deixará seus assemblies inalterados e reduzirá o tamanho dos assemblies do SDK (ou seja, o que é fornecido com o Xamarin.iOS) removendo tudo o que seu aplicativo não usa. Essa é a configuração padrão quando seu IDE se destina a dispositivos iOS.
+Nesse modo, o _linker_ deixará seus assemblies inalterados e reduzirá o tamanho dos assemblies do SDK (ou seja, o que é fornecido com o Xamarin.iOS) removendo tudo o que seu aplicativo não usa. Essa é a configuração padrão quando seu IDE se destina a dispositivos iOS.
 
-Essa é a opção mais simples, pois não requer nenhuma alteração ao código. A diferença observada vinculando-se tudo é que o vinculador não pode executar algumas otimizações nesse modo, portanto, então trata-se de uma compensação entre o trabalho necessário para vincular tudo e o tamanho final do aplicativo.
+Essa é a opção mais simples, pois não requer nenhuma alteração ao código. A diferença observada vinculando-se tudo é que o _linker_ não pode executar algumas otimizações nesse modo, portanto, então trata-se de uma compensação entre o trabalho necessário para vincular tudo e o tamanho final do aplicativo.
 
 Isso corresponde à opção *-linksdk* ao usar a ferramenta de linha de comando mtouch.
 
@@ -71,7 +70,7 @@ Isso corresponde à opção *-linksdk* ao usar a ferramenta de linha de comando 
 
 ### <a name="link-all-assemblies"></a>Vincular todos os assemblies
 
-Ao vincular tudo, o vinculador pode usar o conjunto completo de suas otimizações para tornar o aplicativo tão pequeno quanto possível. Ele modificará o código do usuário, que poderá falhar sempre que o código usar recursos de uma maneira não detectável pela análise estática do vinculador. Nesses casos, por exemplo, webservices, reflexão ou serialização, alguns ajustes podem ser necessários em seu aplicativo para vincular tudo.
+Ao vincular tudo, o _linker_ pode usar o conjunto completo de suas otimizações para tornar o aplicativo o menor possível. Ele modificará o código do usuário, que poderá falhar sempre que o código usar recursos de uma maneira não detectável pela análise estática do _linker_. Nesses casos, por exemplo, webservices, _reflection_ ou serialização, alguns ajustes podem ser necessários em seu aplicativo para vincular tudo.
 
 Isso corresponde à opção *-linkall* ao usar a ferramenta de linha de comando **mtouch**.
 
@@ -79,15 +78,15 @@ Isso corresponde à opção *-linkall* ao usar a ferramenta de linha de comando 
 
 ## <a name="controlling-the-linker"></a>Controlar o vinculador
 
-Quando você usar o vinculador, ele às vezes será removerá código que você poderia ter chamado dinamicamente, ainda que indiretamente. Para abranger esses casos, o vinculador fornece alguns recursos e opções para permitir maior controle sobre as ações dele.
+Quando você usar o _linker_, ele às vezes removerá código que você pode ter chamado dinamicamente, ainda que indiretamente. Para abranger esses casos, o _linker_ fornece alguns recursos e opções para permitir maior controle sobre as ações dele.
 
 <a name="Preserving_Code" />
 
 ### <a name="preserving-code"></a>Preservação do código
 
-Quando você usa o vinculador, ele pode às vezes remover código que você pode ter chamado dinamicamente usando System.Reflection.MemberInfo.Invoke, ou então exportando seus métodos para Objective-C usando o atributo `[Export]` e, em seguida, invocando o seletor manualmente.
+Quando você usa o _linker_, ele pode às vezes remover código que você pode ter chamado dinamicamente usando System.Reflection.MemberInfo.Invoke, ou então exportando seus métodos para Objective-C usando o atributo `[Export]` e, em seguida, invocando o seletor manualmente.
 
-Nesses casos, você pode instruir o vinculador para considerar classes inteiras para serem usadas ou então membros individuais a serem preservados, aplicando o atributo `[Xamarin.iOS.Foundation.Preserve]` no nível de classe ou no nível de membro. Cada membro que não está vinculado estaticamente pelo aplicativo está sujeito a ser removido. Portanto, este atributo é usado para marcar membros que não são referenciados estaticamente, mas que ainda são necessários para o seu aplicativo.
+Nesses casos, você pode instruir o _linker_ para considerar classes inteiras para serem usadas ou então membros individuais a serem preservados, aplicando o atributo `[Xamarin.iOS.Foundation.Preserve]` no nível de classe ou no nível de membro. Cada membro que não está vinculado estaticamente pelo aplicativo está sujeito a ser removido. Portanto, este atributo é usado para marcar membros que não são referenciados estaticamente, mas que ainda são necessários para o seu aplicativo.
 
 Por exemplo, se você cria uma instância de tipos dinamicamente, convém preservar o construtor padrão de seus tipos. Se você usar a serialização de XML, você talvez queira preservar as propriedades de seus tipos.
 
@@ -107,13 +106,13 @@ public sealed class PreserveAttribute : System.Attribute {
 }
 ```
 
-Não importa em qual namespace isso é definido, o vinculador procura esse atributo pelo nome do tipo.
+Não importa em qual namespace isso é definido, o _linker_ procura esse atributo pelo nome do tipo.
 
  <a name="Skipping_Assemblies" />
 
 ### <a name="skipping-assemblies"></a>Ignorar assemblies
 
-É possível especificar os assemblies que devem ser excluídos do processo do vinculador, permitindo simultaneamente que outros assemblies sejam vinculados normalmente. Isso é útil se usar `[Preserve]` em alguns assemblies é impossível (por exemplo, com código de terceiros) ou como uma solução temporária para um bug.
+É possível especificar os assemblies que devem ser excluídos do processo do _linker_, permitindo simultaneamente que outros assemblies sejam vinculados normalmente. Isso é útil se usar `[Preserve]` em alguns assemblies é impossível (por exemplo, com código de terceiros) ou como uma solução temporária para um bug.
 
 Isso corresponde à opção `--linkskip` ao usar a ferramenta de linha de comando mtouch.
 
@@ -123,7 +122,7 @@ Ao usar opção **Vincular Todos os Assemblies**, se você quiser dizer ao vincu
 --linkskip=NameOfAssemblyToSkipWithoutFileExtension
 ```
 
-Se você deseja que o vinculador ignore vários assemblies, inclua vários argumentos `linkskip`:
+Se você deseja que o _linker_ ignore vários assemblies, inclua vários argumentos `linkskip`:
 
 ```csharp
 --linkskip=NameOfFirstAssembly --linkskip=NameOfSecondAssembly
@@ -135,26 +134,26 @@ Não há nenhuma interface do usuário para usar essa opção, mas ela pode ser 
 
 ### <a name="disabling-link-away"></a>Desabilitar a Remoção
 
-O vinculador removerá código que tem uma chance muito baixa de ser usado em dispositivos, por exemplo, que não é compatível ou não é permitido. Em raras ocasiões, é possível que um aplicativo ou a biblioteca dependa desse código (funcionando ou não). Desde o Xamarin.iOS 5.0.1, o vinculador pode ser instruído a ignorar essa otimização.
+O _linker_ removerá código que tem uma chance muito baixa de ser usado em dispositivos, por exemplo, que não é compatível ou não é permitido. Em raras ocasiões, é possível que um aplicativo ou a biblioteca dependa desse código (funcionando ou não). Desde o Xamarin.iOS 5.0.1, o _linker_ pode ser instruído a ignorar essa otimização.
 
 Isso corresponde à opção *-nolinkaway* ao usar a ferramenta de linha de comando mtouch.
 
 Não há nenhuma interface do usuário para usar essa opção, mas ela pode ser fornecida na caixa de diálogo Opções do Projeto do Visual Studio para Mac ou no painel Propriedades do projeto do Visual Studio, dentro do campo de texto **Argumentos adicionais do mtouch**. (por exemplo, *--nolinkaway* não removeria o código extra (cerca de 100 KB)).
 
-### <a name="marking-your-assembly-as-linker-ready"></a>Marcar o assembly como pronto para o vinculador
+### <a name="marking-your-assembly-as-linker-ready"></a>Marcar o assembly como pronto para o Linker
 
-Os usuários podem selecionar a opção de apenas vincular os assemblies do SDK, sem nenhuma vinculação ao seu código.  Isso também significa que todas as bibliotecas de terceiros que não fazem parte do SDK principal do Xamarin não serão vinculadas.
+Os usuários podem selecionar a opção de apenas vincular os assemblies do SDK, sem nenhuma vinculação ao seu código. Isso também significa que todas as bibliotecas de terceiros que não fazem parte do SDK principal do Xamarin não serão vinculadas.
 
-Isso normalmente acontece porque eles não desejam adicionar manualmente atributos `[Preserve]` ao seu código.  O efeito colateral é que bibliotecas de terceiros não serão vinculadas, o que geralmente é um bom padrão, pois não é possível saber se uma outra biblioteca de terceiros é compatível funciona bem com o vinculador ou não.
+Isso normalmente acontece porque eles não desejam adicionar manualmente atributos `[Preserve]` ao seu código.  O efeito colateral é que bibliotecas de terceiros não serão vinculadas, o que geralmente é um bom padrão, pois não é possível saber se uma outra biblioteca de terceiros é compatível com o _linker_ ou não.
 
-Se você tiver uma biblioteca no seu projeto ou se você for um desenvolvedor de bibliotecas reutilizáveis e desejar que o vinculador trate o assembly como vinculável, tudo o que você precisa fazer é adicionar o atributo no nível de assembly [`LinkerSafe`](https://developer.xamarin.com/api/type/Foundation.LinkerSafeAttribute/), assim:
+Se você tiver uma biblioteca no seu projeto ou se você for um desenvolvedor de bibliotecas reutilizáveis e desejar que o _linker_ trate o assembly como vinculável, tudo o que você precisa fazer é adicionar o atributo no nível de assembly [`LinkerSafe`](https://developer.xamarin.com/api/type/Foundation.LinkerSafeAttribute/), assim:
 
 ```csharp
 [assembly:LinkerSafe]
 ```
 
 A biblioteca não precisa efetivamente fazer referência às bibliotecas Xamarin para isso.  Por exemplo, se você está compilando uma biblioteca de classes portátil que será executada em outras plataformas, pode ainda usar um atributo `LinkerSafe`.
-O vinculador do Xamarin procura o atributo `LinkerSafe` por nome, não pelo seu tipo.  Isso significa que você pode escrever este código e ele também funcionará:
+O _linker_ do Xamarin procura o atributo `LinkerSafe` por nome, não pelo seu tipo.  Isso significa que você pode escrever este código e ele também funcionará:
 
 ```csharp
 [assembly:LinkerSafe]
@@ -162,13 +161,13 @@ O vinculador do Xamarin procura o atributo `LinkerSafe` por nome, não pelo seu 
 class LinkerSafeAttribute : System.Attribute {}
 ```
 
-## <a name="custom-linker-configuration"></a>Configuração personalizada do vinculador
+## <a name="custom-linker-configuration"></a>Configuração personalizada do Linker
 
 Siga as [instruções para criar um arquivo de configuração do vinculador](~/cross-platform/deploy-test/linker.md).
 
 
 ## <a name="related-links"></a>Links relacionados
 
-- [Configuração personalizada do vinculador](~/cross-platform/deploy-test/linker.md)
-- [Vinculação no Mac](~/mac/deploy-test/linker.md)
-- [Vinculação no Android](~/android/deploy-test/linker.md)
+- [Configuração personalizada do Linker](~/cross-platform/deploy-test/linker.md)
+- [Usando Linker no Mac](~/mac/deploy-test/linker.md)
+- [Usando Linker no Android](~/android/deploy-test/linker.md)


### PR DESCRIPTION
The original translation used _Vinculador_ for _Linker_, in many places this feels wrong as it doesn't look like Linker is referencing a tool. It is like translating MSBuild or something. 

I changed it back to Linker everywhere it made sense.